### PR TITLE
Implement `Indent` functions

### DIFF
--- a/src/Data/Text/Wrap.hs
+++ b/src/Data/Text/Wrap.hs
@@ -85,8 +85,8 @@ dedent text = undefined
 
 -- | Remove common leading whitespace from all lines
 -- | Finds line breaks based on the given locale
-dedentLocale :: LocaleName -> Text -> Text
-dedentLocale locale text = undefined
+dedentWithLocale :: LocaleName -> Text -> Text
+dedentWithLocale locale text = undefined
 
 
 -- | Add 'prefix' to all lines matching the given predicate

--- a/src/Data/Text/Wrap.hs
+++ b/src/Data/Text/Wrap.hs
@@ -1,9 +1,26 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Data.Text.Wrap where
+module Data.Text.Wrap(
+      WrapError(..)
+    , WrapperConfig(..)
+    , defaultConfig
+    , wrap
+    , fill
+    , shorten
+    , dedent
+    , dedentLocale
+    , indent
+    , indentWithLocale
+    ) where
+
+import Data.Maybe(fromMaybe)
+import Data.List(groupBy)
+import Data.Function(on)
 
 import Data.Text (Text)
 import qualified Data.Text as T
+import Data.Text.ICU
 import Data.Text.ICU.Types
+
 
 -- | A type representing the possible errors produced by
 -- | running one of the wrapping functions with invalid inputs
@@ -12,7 +29,7 @@ data WrapError = InvalidWidth | PlaceholderTooLarge
 
 
 -- | A collection of config information
-data WrapperConfig = 
+data WrapperConfig =
   WrapperConfig { width              :: Int -- ^ Maximum length of a wrapped line
                 , expandTabs         :: Bool -- ^ If true, all tabs will be replaced with spaces
                 , tabsize            :: Int -- ^ Number of spaces to use for a tab if 'expandTabs' is true
@@ -73,10 +90,43 @@ dedentLocale locale text = undefined
 
 
 -- | Add 'prefix' to all lines matching the given predicate
+-- | If no predicate is supplied, adds 'prefix' to all lines that don't consist
+-- | solely of whitespace
 indent :: Maybe (Text -> Bool) -> Text -> Text -> Text
-indent pred prefix text = undefined
+indent = indentWithLocale Current
+
 
 -- | Add 'prefix' to all lines matching the given predicate
+-- | If no predicate is supplied, adds 'prefix' to all lines that don't consist
+-- | solely of whitespace
 -- | Finds line breaks based on the given locale
 indentWithLocale :: LocaleName -> Maybe (Text -> Bool) -> Text -> Text -> Text
-indentWithLocale local pred prefix text = undefined
+indentWithLocale locale pred prefix = T.concat . fmap transform . linebreaks . breaks (breakLine locale)
+  where
+    transform :: Text -> Text
+    transform break = if pred' break
+                      then prefix `T.append` break
+                      else break
+
+    pred' = fromMaybe defaultPred pred
+    defaultPred ln = T.strip ln /= T.empty
+
+
+-- collect lines by hard breaks
+-- soft breaks are accumulated and then attached to the next hard break
+-- so [Hard, Soft, Soft, Hard, Hard, Hard, Soft] becomes
+-- [Hard, 2Soft+Hard, Hard, Hard, Soft]
+linebreaks :: [Break Line] -> [Text]
+linebreaks = composeLines . concatMap breaksToTexts . groupBy ((==) `on` brkStatus)
+  where
+    breaksToTexts :: [Break Line] -> [(Text, Line)]
+    breaksToTexts [] = []
+    breaksToTexts chunks = case brkStatus (head chunks) of
+                             Soft -> [(T.concat $ fmap brkBreak chunks, Soft)]
+                             Hard -> fmap (\chunk -> (brkBreak chunk, Hard)) chunks
+
+    composeLines :: [(Text, Line)] -> [Text]
+    composeLines [] = []
+    composeLines [(text, _)] = [text]
+    composeLines ((text, Hard):lns) = text : composeLines lns
+    composeLines ((text, Soft):ln:lns) = text `T.append` fst ln : composeLines lns


### PR DESCRIPTION
All `indent` tests now pass, excepting the round trip tests which need `dedent` to be implemented as well.
