### PR TITLE
Implement wrap function

### DIFF
--- a/src/Data/Text/Wrap.hs
+++ b/src/Data/Text/Wrap.hs
@@ -85,9 +85,9 @@ wrap cfg txt | width cfg < 1   = Left InvalidWidth
              | tabsize cfg < 0 = Left InvalidTabSize
              | T.length ii >= width cfg || T.length si >= width cfg = Left IndentTooLong
              | fromMaybe False ((<1) <$> maxLines cfg) = Left InvalidLineCount
-             | isJust (maxLines cfg) && T.length (placeholder cfg) >= width cfg = Left PlaceholderTooLarge
-             | fromMaybe False ((==1) <$> maxLines cfg) && T.length (placeholder cfg) + T.length ii >= (width cfg) = Left PlaceholderTooLarge
-             | isJust (maxLines cfg) && T.length (placeholder cfg) + T.length si >= (width cfg) = Left PlaceholderTooLarge
+             | isJust (maxLines cfg) && T.length (placeholder cfg) > width cfg = Left PlaceholderTooLarge
+             | fromMaybe False ((==1) <$> maxLines cfg) && T.length (placeholder cfg) + T.length (T.stripEnd ii) > width cfg = Left PlaceholderTooLarge
+             | isJust (maxLines cfg) && T.length (placeholder cfg) + T.length (T.stripEnd si) > width cfg = Left PlaceholderTooLarge
              | otherwise =
                 Right $ wrapChunks $ collect (breakOnHyphens cfg) $ breaks (breakWord (locale cfg)) $ preprocess txt
   where
@@ -134,7 +134,7 @@ wrap cfg txt | width cfg < 1   = Left InvalidWidth
                    (Nothing, False) -> filter (not . T.null) . wrapNoBreak
                    (Nothing, True)  -> filter (not . T.null) . wrapBreak
                    (Just n, False)  -> filter (not . T.null) . wrapLinesNoBreak n
-                   (Just n, True)   -> filter (not . T.null) . wrapLinesNoBreak (n - 1)
+                   (Just n, True)   -> filter (not . T.null) . undefined
 
     wrapNoBreak []                          = []
     wrapNoBreak [c] | T.null (maybeStrip c) = []

--- a/src/Data/Text/Wrap.hs
+++ b/src/Data/Text/Wrap.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE BangPatterns #-}
 module Data.Text.Wrap(
       WrapError(..)
     , WrapperConfig(..)
@@ -24,10 +25,15 @@ import Data.Text.ICU
 import Data.Text.ICU.Char
 import Data.Text.ICU.Types
 
+import Prelude hiding (Word)
 
 -- | A type representing the possible errors produced by
 -- | running one of the wrapping functions with invalid inputs
-data WrapError = InvalidWidth | PlaceholderTooLarge
+data WrapError = InvalidWidth
+               | InvalidTabSize
+               | IndentTooLong
+               | InvalidLineCount
+               | PlaceholderTooLarge
   deriving (Show, Eq)
 
 
@@ -36,6 +42,7 @@ data WrapperConfig =
   WrapperConfig { width              :: Int -- ^ Maximum length of a wrapped line
                 , expandTabs         :: Bool -- ^ If true, all tabs will be replaced with spaces
                 , tabsize            :: Int -- ^ Number of spaces to use for a tab if 'expandTabs' is true
+                , useTabStops        :: Bool -- ^ If true, aligns tabs on nearest multiple of tabsize
                 , replaceWhitespace  :: Bool -- ^ Replace all whitespace with spaces before wrapping
                 , dropWhitespace     :: Bool -- ^ Drop whitespace around lines
                 , initialIndent      :: Text -- ^ Text prepended to the first line
@@ -53,6 +60,7 @@ defaultConfig :: WrapperConfig
 defaultConfig = WrapperConfig { width = 70
                               , expandTabs = True
                               , tabsize = 8
+                              , useTabStops = True
                               , replaceWhitespace = True
                               , dropWhitespace = True
                               , initialIndent = ""
@@ -65,10 +73,197 @@ defaultConfig = WrapperConfig { width = 70
                               , locale = Current
                               }
 
+
+-- information used while wrapping
+data Chunk = Chunk Text ChunkType
+  deriving (Show, Eq)
+
+
+-- Equivalent to the status field of an ICU Break,
+-- but seperate hyphens from Uncategorized
+data ChunkType = Number_
+               | Letters_
+               | Kana_
+               | Ideograph_
+               | Hyphens_
+               | Punctuation
+               | Uncategorized_
+               | Empty
+  deriving (Show, Eq)
+
+
+emptyChunk = Chunk "" Empty
+
+
+breakToChunk :: Break Word -> Chunk
+breakToChunk brk = case brkStatus brk of
+                     Number -> Chunk txt Number_
+                     Letter -> Chunk txt Letters_
+                     Kana   -> Chunk txt Kana_
+                     Ideograph -> Chunk txt Ideograph_
+                     Uncategorized -> punctuation (T.head txt)
+  where txt = brkBreak brk
+        punctuation c | c == '-' = Chunk txt Hyphens_
+                      | isPunctuation c = Chunk txt Punctuation
+                      | otherwise = Chunk txt Uncategorized_
+
+        isPunctuation c = property GeneralCategory c `elem` validPunctuation
+
+
+validPunctuation :: [GeneralCategory]
+validPunctuation = [ DashPunctuation
+                   , StartPunctuation
+                   , EndPunctuation
+                   , ConnectorPunctuation
+                   , OtherPunctuation
+                   ]
+
+
 -- | Wraps the input text, returning a list of lines no more than 'width'
 -- | characters long
 wrap :: WrapperConfig -> Text -> Either WrapError [Text]
-wrap = undefined
+wrap _ "" = Right []
+wrap cfg txt | width cfg < 1 = Left InvalidWidth
+             | tabsize cfg < 0 = Left InvalidTabSize
+             | T.length ii >= width cfg || T.length si >= width cfg = Left IndentTooLong
+             | fromMaybe False ((<1) <$> maxLines cfg) = Left InvalidLineCount
+             | otherwise = Right $
+                 wrapChunks $  combineChunks $ breaks (breakWord (locale cfg)) $ preprocess txt
+  where
+    ii = initialIndent cfg
+    si = subsequentIndent cfg
+    preprocess :: Text -> Text
+    preprocess = fixSentences . substitueWhitespace . tabsToSpaces
+
+    tabsToSpaces = if expandTabs cfg
+                   then if useTabStops cfg
+                        then mconcat . fmap (expandToTabBoundry . T.split (=='\t')) . linebreaks (locale cfg)
+                        else T.replace "\t" (T.replicate (tabsize cfg) " ")
+                   else id
+
+    expandToTabBoundry []   = ""
+    expandToTabBoundry [ln] = ln
+    expandToTabBoundry lns = expandToTabBoundry' (0, "") lns
+
+    expandToTabBoundry' (!len, !text) [ln] = text <> ln
+    expandToTabBoundry' (!len, !text) (ln:lns) = expandToTabBoundry' (len + ilen, text <> ln <> ind) lns
+      where
+        ind = T.replicate indlen " "
+        indlen = (tabsize cfg) - ((len + T.length ln) `mod` (tabsize cfg))
+        ilen = indlen + T.length ln
+
+    substitueWhitespace = if replaceWhitespace cfg
+                          then T.map (\c -> if isSpace c then ' ' else c)
+                          else id
+
+    fixSentences | fixSentenceEndings cfg = T.concat . fmap (sentenceWhitespace . brkBreak) . breaks (breakSentence (locale cfg))
+                 | otherwise = id
+
+    sentenceWhitespace ln = let trailingWhitespace = T.takeWhileEnd isSpace ln
+                                breakPart = T.takeWhileEnd isBreak trailingWhitespace
+                             in T.concat [T.dropWhileEnd isSpace ln, "  ", breakPart]
+
+
+  --TODO: almost everything below here needs a better name
+
+    mergeHyphens chk@(Chunk !c _) [] = [chk]
+    mergeHyphens (Chunk _ Empty) (c:cs) = mergeHyphens c cs
+    mergeHyphens (Chunk !h Hyphens_) ((Chunk h' Hyphens_):cs) = mergeHyphens (Chunk (h <> h') Hyphens_) cs
+    mergeHyphens chk@(Chunk _ _) (c:cs) = chk : mergeHyphens c cs
+
+    combineChunks :: [Break Word] -> [Text]
+    combineChunks = combineChunks' emptyChunk . mergeHyphens emptyChunk . fmap breakToChunk
+
+    combineChunks' :: Chunk -> [Chunk] -> [Text]
+    combineChunks' (Chunk !c _) [] = [c]
+    combineChunks' (Chunk _ Empty) (c:cs) = combineChunks' c cs
+    combineChunks' (Chunk !h Hyphens_) ((Chunk c Letters_):cs) = combineChunks' (Chunk (h <> c) Letters_) cs
+                                                               -- | otherwise = h : combineChunks' (Chunk c Letters_) cs
+    combineChunks' (Chunk !p Punctuation) ((Chunk w Letters_):cs) | p == "\'" || p == "\"" = combineChunks' (Chunk (p <> w) Letters_) cs
+                                                                  | otherwise = p : combineChunks' (Chunk w Letters_) cs
+    -- combineChunks' (Chunk !h Hyphens_) ((Chunk h' Hyphens_):cs) = combineChunks' (Chunk (h <> h') Hyphens_) cs
+    combineChunks' (Chunk !c Letters_) ((Chunk h Hyphens_):(Chunk c' Letters_):cs) | not (breakOnHyphens cfg) && h == "-" = combineChunks' (Chunk (c <> h <> c') Letters_) cs
+                                                                                   | breakOnHyphens cfg && h == "-" = (c <> h) : combineChunks' (Chunk c' Letters_) cs
+                                                                                   | otherwise = c : h : combineChunks' (Chunk c' Letters_) cs
+    combineChunks' (Chunk !c Letters_) ((Chunk h Hyphens_):cs) | breakOnHyphens cfg && h == "-" = (c <> h) : combineChunks' emptyChunk cs
+                                                               | h == "--" = c : combineChunks' (Chunk h Hyphens_) cs
+                                                               | not (breakOnHyphens cfg) && h == "-" = combineChunks' (Chunk (c <> h) Letters_) cs
+                                                               | otherwise = c : combineChunks' (Chunk h Hyphens_) cs
+    combineChunks' (Chunk !c Letters_) ((Chunk p Punctuation):cs) = combineChunks' (Chunk (c <> p) Letters_) cs
+    combineChunks' (Chunk !n Number_) ((Chunk h Hyphens_):(Chunk n' Number_):cs) = combineChunks' (Chunk (n <> h <> n') Number_) cs
+    combineChunks' (Chunk !n Number_) ((Chunk p Punctuation):cs) = combineChunks' (Chunk (n <> p) Number_) cs
+    combineChunks' (Chunk !w Uncategorized_) ((Chunk w' Uncategorized_):cs) = combineChunks' (Chunk (w <> w') Uncategorized_) cs
+    combineChunks' (Chunk !c _) (c':cs) = c : combineChunks' c' cs
+
+
+    wrapChunks :: [Text] -> [Text]
+    wrapChunks = case (maxLines cfg, breakLongWords cfg) of
+                   (Nothing, False) -> filter (not . T.null) . wrapNoBreak
+                   (Nothing, True)  -> filter (not . T.null) . wrapBreak
+                   (Just n, False)  -> undefined
+                   (Just n, True)   -> undefined
+
+    wrapNoBreak [] = []
+    wrapNoBreak [c] | T.null (maybeStrip c) = []
+                    | otherwise = [ii <> maybeStrip c]
+    wrapNoBreak (c:cs) | T.null c' = fmap (si <>) cs'
+                       | otherwise = (ii <> c') : fmap (si <>) cs'
+      where (c':cs') = goNoBreak ii (T.length c, c) cs
+
+    wrapBreak [] = []
+    wrapBreak [c] | T.null (maybeStrip c) = []
+                  | otherwise = [ii <> maybeStrip c] --This is wrong, might need to break
+    wrapBreak (c:cs) | T.null c' = fmap (si <>) cs'
+                     | otherwise = (ii <> c') : fmap (si <>) cs'
+      where (c':cs') = goBreak ii (T.length c, c) cs
+
+    maybeStrip = if dropWhitespace cfg then T.strip else id
+
+    maybeStripEnd = if dropWhitespace cfg then T.stripEnd else id
+
+    dropWhitespaceTokens = if dropWhitespace cfg
+                           then dropWhile (T.any isSpace)
+                           else id
+
+    goNoBreak :: Text -> (Int, Text) -> [Text] -> [Text]
+    goNoBreak i (!len, !text) [] | T.null text = []
+                                 | otherwise   = [maybeStripEnd text]
+    goNoBreak i (!len, !text) (c:cs) | T.null text = goNoBreak i (clen, c) cs
+                                     | clen > wdth = maybeStripEnd text : maybeStrip c : (goNoBreak si (0,"") (dropWhitespaceTokens cs))
+                                     | clen + len <= wdth = goNoBreak i (len + clen, text <> c) cs
+                                     | otherwise = maybeStripEnd text : (goNoBreak si (0, "") (dropWhitespaceTokens (c:cs)))
+      where
+        clen = T.length c
+        wdth = width cfg - T.length i
+
+    goBreak :: Text -> (Int, Text) -> [Text] -> [Text]
+    goBreak i (!len, !text) [] = [maybeStripEnd text]
+    goBreak i (!len, !text) (c:cs) | clen > wdth = (text <> c1) : (goBreak si (0, "") (c2:cs))
+                                   | clen + len <= wdth = goBreak i (len + clen, text <> c) cs
+                                   | otherwise = maybeStripEnd text : (goBreak si (0, "") (dropWhitespaceTokens (c:cs)))
+      where
+        clen = T.length c
+        wdth = width cfg - T.length i
+        (c1,c2) = T.splitAt (wdth - len) c
+
+    -- wrap' [] = []
+    -- wrap' [c] | T.length c > width cfg + T.length ii && breakLongWords cfg = ii <> c1 : fmap ((si<>) . T.strip) (go (0,"") [c2])
+    --           | otherwise = [ii <> c]
+    --   where (c1,c2) = wrapLongWord (T.length ii) (T.strip c)
+    -- wrap' cs = fmap ((si<>). T.strip) (go (0,"") cs)
+
+    -- go (!len, !text) [] = [text]
+    -- go (!len, !text) (c:cs) | clen > wdth && not (breakLongWords cfg) = text : c : go (0,"") cs
+    --                         | clen > wdth && breakLongWords cfg = (text <> hd) : go (0, "") (tl:cs)
+    --                         | clen + len < wdth = go (len + clen, text <> c) cs
+    --                         | otherwise = text : go (0, "") (c:cs)
+    --   where clen = T.length c
+    --         ilen = T.length si
+    --         wdth = width cfg - ilen
+    --         (hd,tl) = wrapLongWord len c
+ 
+    -- wrapLongWord :: Int -> Text -> (Text,Text)
+    -- wrapLongWord len text = T.splitAt (width cfg - len) text
 
 
 -- | Like wrap, but concatinates lines and adds newlines

--- a/src/Data/Text/Wrap.hs
+++ b/src/Data/Text/Wrap.hs
@@ -15,7 +15,6 @@ module Data.Text.Wrap(
     ) where
 
 import Data.Char(isSpace)
-import Data.Either(partitionEithers)
 import Data.Function(on)
 import Data.List(foldl1', groupBy)
 import Data.Maybe(isJust, fromMaybe, fromJust)
@@ -187,9 +186,9 @@ wrap cfg txt = validateConfig cfg >>
 
     -- handle cleanup around the last line when breaking
     handleBreak n lines = case splitAt (n - 1) lines of
-      (_, [])           -> catTokens <$> lines
-      (_, [last])       -> catTokens <$> lines
-      (lines', last:ls) -> catTokens <$> lines' <> [fixupEnd last]
+      (_, [])          -> catTokens <$> lines
+      (_, [_])         -> catTokens <$> lines
+      (lines', last:_) -> catTokens <$> lines' <> [fixupEnd last]
       where
         fixupEnd tokens =
         -- TODO: should get length some other way

--- a/src/Data/Text/Wrap/Internal/Tokens.hs
+++ b/src/Data/Text/Wrap/Internal/Tokens.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE BangPatterns #-}
+module Data.Text.Wrap.Internal.Tokens(
+      collect
+    ) where
+
+import Data.Monoid((<>))
+ 
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.ICU as ICU
+import Data.Text.ICU.Char (GeneralCategory(..), GeneralCategory_(..), property)
+
+
+-- information used while wrapping
+data Token = Number Text
+           | Letters Text
+           | Kana Text
+           | Ideograph Text
+           | Hyphens Text
+           | Punctuation Text
+           | Uncategorized Text
+           | Empty
+  deriving (Show, Eq)
+
+
+type ICUBreak = ICU.Break ICU.Word
+
+
+text :: Token -> Text
+text (Number t)        = t
+text (Letters t)       = t
+text (Kana t)          = t
+text (Ideograph t)     = t
+text (Hyphens t)       = t
+text (Punctuation t)   = t
+text (Uncategorized t) = t
+text Empty             = ""
+
+
+collect :: Bool -> [ICUBreak] -> [Text]
+collect breakOnHyphens = collectTokens breakOnHyphens . mergeHyphens . fmap breakToToken
+
+
+breakToToken :: ICUBreak -> Token
+breakToToken brk = case ICU.brkStatus brk of
+                     ICU.Number        -> Number txt
+                     ICU.Letter        -> Letters txt
+                     ICU.Kana          -> Kana txt
+                     ICU.Ideograph     -> Ideograph txt
+                     ICU.Uncategorized -> punctuation (T.head txt)
+  where txt = ICU.brkBreak brk
+        punctuation c | c == '-'        = Hyphens txt
+                      | isPunctuation c = Punctuation txt
+                      | otherwise       = Uncategorized txt
+
+        isPunctuation c = property GeneralCategory c `elem` validPunctuation
+
+
+validPunctuation :: [GeneralCategory]
+validPunctuation = [ DashPunctuation
+                   , StartPunctuation
+                   , EndPunctuation
+                   , ConnectorPunctuation
+                   , OtherPunctuation
+                   ]
+
+mergeHyphens :: [Token] -> [Token]
+mergeHyphens = mergeHyphens' Empty
+  where
+    mergeHyphens' !tok []                         = [tok]
+    mergeHyphens' Empty (tk:tks)                  = mergeHyphens' tk tks
+    mergeHyphens' (Hyphens !h) (Hyphens h' : tks) = mergeHyphens' (Hyphens (h <> h')) tks
+    mergeHyphens' !tok (tk:tks)                   = tok : mergeHyphens' tk tks
+
+
+collectTokens :: Bool -> [Token] -> [Text]
+collectTokens breakOnHyphens = collectTokens' Empty
+  where
+    collectTokens' !tok []                         = [text tok]
+    collectTokens' Empty (tk:tks)                  = collectTokens' tk tks
+    collectTokens' (Hyphens !h) (Letters ls : tks) = collectTokens' (Letters (h <> ls)) tks
+    collectTokens' (Punctuation !p) (Letters ls : tks)
+      | p == "\'" || p == "\"" = collectTokens' (Letters (p <> ls)) tks
+      | otherwise              = p : collectTokens' (Letters ls) tks
+    collectTokens' (Letters !ls) (Hyphens h : Letters ls' : tks)
+      | h == "-"  = case breakOnHyphens of
+                      False -> collectTokens' (Letters (ls <> h <> ls')) tks
+                      True  -> (ls <> h) : collectTokens' (Letters ls') tks
+      | otherwise = ls : h : collectTokens' (Letters ls') tks
+    collectTokens' (Letters !ls) (Hyphens h : tks)
+      | h == "-"  = case breakOnHyphens of
+                      True  -> (ls <> h) : collectTokens' Empty tks
+                      False -> collectTokens' (Letters (ls <> h)) tks
+      | otherwise = ls : collectTokens' (Hyphens h) tks
+    collectTokens' (Letters !ls) (Punctuation p : tks)         = collectTokens' (Letters (ls <> p)) tks
+    collectTokens' (Number !n) (Hyphens h : Number n' : tks)   = collectTokens' (Number (n <> h <> n')) tks
+    collectTokens' (Number !n) (Punctuation p : tks)           = collectTokens' (Number (n <> p)) tks
+    collectTokens' (Uncategorized !u) (Uncategorized u' : tks) = collectTokens' (Uncategorized (u <> u')) tks
+    collectTokens' !tok (tk:tks)                               = text tok : collectTokens' tk tks

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -348,7 +348,7 @@ maxLinesTests = describe "Max Lines" $ do
         , "day? [...]" ]
 
     it "puts the placeholder at the start of the line if nothing fits" $
-      testWrapLines 6 2 text ["Hello", "[...]"]
+      testWrapLines 7 2 text ["Hello", "[...]"]
 
     it "doesn't use a placeholder for trailing spaces" $
       testWrapLines 12 6 (text `T.append` T.replicate 10 " ")
@@ -366,21 +366,21 @@ maxLinesTests = describe "Max Lines" $ do
       check 12 1 "..." text ["Hello..."]
       check 12 2 "..." text ["Hello there,", "how are..."]
 
-    it "returns an error when the placeholder and indentation are too long" $ do
+    it "returns an error when the placeholder and non-whitespace indentation are too long" $ do
       TW.wrap testConfig{ width = 16
                         , maxLines = Just 1
-                        , initialIndent = "    "
+                        , initialIndent = "wat>"
                         , placeholder = " [truncated]..."
                         }
         text `shouldBe` Left TW.PlaceholderTooLarge
       TW.wrap testConfig{ width = 16
                         , maxLines = Just 2
-                        , subsequentIndent = "    "
+                        , subsequentIndent = "why>"
                         , placeholder = " [truncated]..."
                         }
         text `shouldBe` Left TW.PlaceholderTooLarge
 
-    it "handles long placeholders and indentation" $ do
+    it "handles long placeholders and whitespace indentation" $ do
       testWrap testConfig{ width = 16
                         , maxLines = Just 2
                         , initialIndent = "    "

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -43,11 +43,12 @@ testWrapLen len = testWrap testConfig{ width = len }
 
 
 multiLineString :: Text
-multiLineString = [Interp.text|\
+multiLineString = multiLineString' "\t"
+multiLineString' a = [Interp.text|
 This is a paragraph that already has
 line breaks.  But some of its lines are much longer than the others,
 so it needs to be wrapped.
-Some lines are \ttabbed too.
+Some lines are ${a}tabbed too.
 What a mess!
 |]
 
@@ -114,7 +115,7 @@ wrapTests = describe "wrap" $ do
       testWrap cfg "I say, chaps! Anyone for \"tennis?\"\nHmmph!"
                   ["I say, chaps!  Anyone for \"tennis?\"  Hmmph!"]
       testWrap cfg{ width = 20 } "I say, chaps! Anyone for \"tennis?\"\nHmmph!"
-                                ["I say, chaps!', 'Anyone for \"tennis?\"', 'Hmmph!"]
+                                ["I say, chaps!", "Anyone for \"tennis?\"", "Hmmph!"]
       testWrap cfg{ width = 20 } "And she said, \"Go to hell!\"\nCan you believe that?"
                                  [ "And she said, \"Go to"
                                  , "hell!\"  Can you"
@@ -283,7 +284,7 @@ wrapTests = describe "wrap" $ do
 
     it "removes empty lines" $ do
       let text = "abcd    efgh"
-      testWrap cfg{ width = 6 } text ["abcd", "    ", "efgh"]
+      testWrap cfg{ width = 6, dropWhitespace = False } text ["abcd", "    ", "efgh"]
       testWrapLen 6 text ["abcd", "efgh"]
 
     it "doesn't add initial indent if dropping whitespace" $
@@ -297,8 +298,8 @@ wrapTests = describe "wrap" $ do
     it "respects breakOnHyphens" $ do
       let text = "yaba daba-doo"
       let cfg = testConfig{ width = 10 }
-      testWrap cfg{ breakOnHyphens = True  } text ["yaba daba-", "doo"]
-      testWrap cfg text ["yaba", "daba-doo"]
+      testWrap cfg text ["yaba daba-", "doo"]
+      testWrap cfg{ breakOnHyphens = False } text ["yaba", "daba-doo"]
 
   describe "Bad Width" $
     it "returns an error for invalid width values" $ do
@@ -325,7 +326,7 @@ maxLinesTests = describe "Max Lines" $ do
   let text = "Hello there, how are you this fine day?  I'm glad to hear it!"
   describe "Simple" $
     it "truncates everything after the line maximum" $ do
-      testWrapLines 12 0 text ["Hello [...]"]
+      TW.wrap testConfig{ width = 12, maxLines = Just 0 } text `shouldBe` Left TW.InvalidLineCount
       testWrapLines 12 1 text ["Hello [...]"]
       testWrapLines 12 2 text ["Hello there,", "how [...]"]
       testWrapLines 13 2 text ["Hello there,", "how are [...]"]
@@ -365,7 +366,7 @@ maxLinesTests = describe "Max Lines" $ do
       check 12 1 "..." text ["Hello..."]
       check 12 2 "..." text ["Hello there,", "how are..."]
 
-    it "returns nothing when the placeholder and indentation are too long" $ do
+    it "returns an error when the placeholder and indentation are too long" $ do
       TW.wrap testConfig{ width = 16
                         , maxLines = Just 1
                         , initialIndent = "    "
@@ -399,7 +400,7 @@ maxLinesTests = describe "Max Lines" $ do
 
 longWordTests :: Spec
 longWordTests = describe "Long Words" $ do
-  let text = [Interp.text|\
+  let text = [Interp.text|
 Did you say "supercalifragilisticexpialidocious?"
 How *do* you spell that odd word, anyways?
 |]
@@ -414,14 +415,14 @@ How *do* you spell that odd word, anyways?
       , "How *do* you spell that odd word, anyways?" ]
 
   it "always breaks *something* off" $
-    testWrap testConfig{ width = 10, subsequentIndent = T.replicate 15 " " }
-      (T.replicate 10 "-" `T.append` "hello")
-        [ "----------"
-        , "               h"
-        , "               e"
-        , "               l"
-        , "               l"
-        , "               o" ]
+    TW.wrap testConfig{ width = 10, subsequentIndent = T.replicate 15 " " }
+      (T.replicate 10 "-" `T.append` "hello") `shouldBe` Left TW.IndentTooLong
+        -- [ "----------"
+        -- , "               h"
+        -- , "               e"
+        -- , "               l"
+        -- , "               l"
+        -- , "               o" ]
 
   -- Prevent a long word to be wrongly wrapped when the
   -- preceding word is exactly one character shorter than the width
@@ -456,12 +457,12 @@ How *do* you spell that odd word, anyways?
 indentTests :: Spec
 indentTests = describe "Indenting" $
   describe "Fill" $ do
-    let text =[Interp.text|\
+    let text =[Interp.text|
 This paragraph will be filled, first without any indentation,
 and then with some (including a hanging indent).|]
     it "fills with no indentation" $
       TW.fill testConfig{ width = 40 } text `shouldBe` Right
-        [Interp.text|\
+        [Interp.text|
 This paragraph will be filled, first
 without any indentation, and then with
 some (including a hanging indent).|]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -348,7 +348,7 @@ maxLinesTests = describe "Max Lines" $ do
         , "day? [...]" ]
 
     it "puts the placeholder at the start of the line if nothing fits" $
-      testWrapLines 7 2 text ["Hello", "[...]"]
+      testWrapLines 7 2 text ["Hello", " [...]"]
 
     it "doesn't use a placeholder for trailing spaces" $
       testWrapLines 12 6 (text `T.append` T.replicate 10 " ")
@@ -387,14 +387,14 @@ maxLinesTests = describe "Max Lines" $ do
                         , subsequentIndent = "  "
                         , placeholder = " [truncated]..."
                         }
-        text ["    Hello there,", "  [truncated]..."]
+        text ["    Hello there,", " [truncated]..."]
       testWrap testConfig{ width = 16
                         , maxLines = Just 1
                         , initialIndent = "   "
                         , subsequentIndent = "   "
                         , placeholder = " [truncated]..."
                         }
-        text ["  [truncated]..."]
+        text [" [truncated]..."]
       testWrap testConfig{ width = 80, placeholder = T.replicate 1000 "." } text [text]
 
 
@@ -447,11 +447,11 @@ How *do* you spell that odd word, anyways?
       , "word, anyways?" ]
 
   it "truncates long words if they go over the max lines" $
-    testWrapLines 30 4 text
+    testWrapLines 12 4 text
       [ "Did you say "
       , "\"supercalifr"
       , "agilisticexp"
-      , "[...]" ]
+      , " [...]" ]
 
 
 indentTests :: Spec

--- a/textwrap.cabal
+++ b/textwrap.cabal
@@ -15,7 +15,8 @@ cabal-version:       >=1.10
 
 library
   hs-source-dirs:      src
-  exposed-modules:     Data.Text.Wrap
+  exposed-modules:     Data.Text.Wrap,
+                       Data.Text.Wrap.Internal.Tokens
   build-depends:       base >= 4.7 && < 5,
                        text >= 0.9.1.0,
                        text-icu >= 0.7.0.1

--- a/textwrap.cabal
+++ b/textwrap.cabal
@@ -20,6 +20,7 @@ library
                        text >= 0.9.1.0,
                        text-icu >= 0.7.0.1
   default-language:    Haskell2010
+  ghc-options:         -Wall
 
 test-suite textwrap-test
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
Implements the `wrap` function using a list of tokens in such a way that the intermediate lists should never be created.
This code is pretty ugly. It should be rewritten with a streaming library like `pipes` or `conduit` once there are benchmarks in place.